### PR TITLE
Adding root pom and GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: temurin
+          cache: maven
+
+      - name: Build and Test
+        run: mvn -B verify
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: '**/target/surefire-reports/'

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.narayana</groupId>
+    <artifactId>narayana-incubator</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Narayana Incubator</name>
+    <description>Incubating components for the Narayana transaction manager</description>
+    <url>https://github.com/jbosstm/incubator</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:https://github.com/jbosstm/incubator.git</connection>
+        <developerConnection>scm:git:git@github.com:jbosstm/incubator.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/jbosstm/incubator</url>
+    </scm>
+
+    <modules>
+        <module>fileio</module>
+        <!-- Requires source/target update from 1.5 to 1.8+ to build on JDK 9+ -->
+        <!-- <module>fileio/quickstart</module> -->
+        <module>lra-annotation-checker</module>
+    </modules>
+
+    <repositories>
+        <repository>
+            <id>jboss-public</id>
+            <name>JBoss Public Repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </repository>
+    </repositories>
+</project>


### PR DESCRIPTION
Commented out <module>fileio/quickstart</module> as it requires java 5. 
We could consider removing old modules in the future.